### PR TITLE
Auto-reconnect on connection drop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-shadow"
-version = "0.1.3"
+version = "0.1.4"
 license = "Apache-2.0"
 authors = ["Karim Agha <karim.dev@gmail.com>"]
 description = "Synchronized shadow state of Solana programs available for off-chain processing."

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -171,16 +171,7 @@ impl BlockchainShadow {
   }
 
   pub fn updates_channel(&self) -> Receiver<(Pubkey, Account)> {
-    debug!(
-      "-> sub -> receiver count: {}",
-      self.ext_updates.receiver_count()
-    );
-    let sub = self.ext_updates.subscribe();
-    debug!(
-      "-> sub -> receiver count: {}",
-      self.ext_updates.receiver_count()
-    );
-    sub
+    self.ext_updates.subscribe()
   }
 }
 
@@ -209,7 +200,10 @@ impl BlockchainShadow {
               Ok(None) => {
                 error!("Websocket connection to solana dropped");
               },
-              Err(e) => error!("error in the sync worker thread: {:?}", e)
+              Err(e) => {
+                error!("error in the sync worker thread: {:?}", e);
+                listener.reconnect_all().await?;
+              }
             }
           },
           Some(subreq) = subscribe_rx.recv() => {


### PR DESCRIPTION
Solana RPC endpoints automatically drop websocket connections when there is no activity for around 30 seconds.
This change automatically reconnects to the Solana WS endpoint and recreates all subscriptions when the socket is closed for whatever reason.